### PR TITLE
layer.conf: Use ROS_OE_RELEASE_SERIES to set LAYERSERIES_COMPAT_*

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -20,7 +20,7 @@ LAYERDEPENDS_ros-webos-layer = " \
     ros-common-layer \
 "
 
-LAYERSERIES_COMPAT_ros-webos-layer = "thud warrior"
+LAYERSERIES_COMPAT_ros-webos-layer = "${ROS_OE_RELEASE_SERIES}"
 
 # Don't allow ROS-only images to be built with DISTRO set to "webos" as they will contain different platform packages, eg, the
 # kernel, from images with the same names built with DISTRO set to "ros1" or "ros2". Using BBMASK instead of PNBLACKLIST because


### PR DESCRIPTION
We can create warrior/zeus/dunfell branches as well at this point, the only difference is LAYERSERIES_COMPAT values. But maybe we will be able to just use ROS_OE_RELEASE_SERIES from meta-ros-common to keep meta-ros-webos branches completely identical.