### PR TITLE
[thud] layer.conf: Use ROS_OE_RELEASE_SERIES to set LAYERSERIES_COMPAT_*

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -20,7 +20,7 @@ LAYERDEPENDS_ros-webos-layer = " \
     ros-common-layer \
 "
 
-LAYERSERIES_COMPAT_ros-webos-layer = "thud warrior"
+LAYERSERIES_COMPAT_ros-webos-layer = "${ROS_OE_RELEASE_SERIES}"
 
 # Don't allow ROS-only images to be built with DISTRO set to "webos" as they will contain different platform packages, eg, the
 # kernel, from images with the same names built with DISTRO set to "ros1" or "ros2". Using BBMASK instead of PNBLACKLIST because


### PR DESCRIPTION
* ROS_OE_RELEASE_SERIES variable was introduced in
  meta-ros-common/conf/ros-distro/ros-distro.conf
  https://github.com/ros/meta-ros/commit/bac9f294e296c4e20ec0fd93b13365e1f5ef623d

* meta-ros-webos is useful only together with meta-ros* layers
  so we can depend on meta-ros-common to be available and use
  ROS_OE_RELEASE_SERIES from there.

* This allows let us to define it in one place, which makes adding
  layers for new ROS releases a bit easier.

Signed-off-by: Martin Jansa <martin.jansa@lge.com>