### PR TITLE
[dunfell] Support webOS OSE v2.7.0

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -18,6 +18,8 @@ LAYERDEPENDS_ros-webos-layer = " \
     meta-python \
     openembedded-layer \
     ros-common-layer \
+    meta-webos \
+    raspberrypi \
 "
 
 LAYERSERIES_COMPAT_ros-webos-layer = "${ROS_OE_RELEASE_SERIES}"

--- a/conf/ros-distro/include/webos-compat.inc
+++ b/conf/ros-distro/include/webos-compat.inc
@@ -366,3 +366,10 @@ PNBLACKLIST[xmlsec1] ?= "ERROR: xmlsec1-1.2.28-r0 do_configure: configure failed
 PNBLACKLIST[remmina] ?= "Depends on blacklisted avahi-ui"
 PNBLACKLIST[telepathy-idle] ?= "Depends on blacklisted telepathy-glib"
 PNBLACKLIST[packagegroup-meta-multimedia] ?= "Depends on blacklisted gstd, gerbera, rygel"
+
+PNBLACKLIST[python3-protobuf] ?= "Not compatible with old protobuf from meta-webos/recipes-devtools/protobuf/protobuf_3.6.1.bb google/protobuf/pyext/message.cc:70:10: fatal error: google/protobuf/stubs/map_util.h: No such file or directory"
+PNBLACKLIST[python3-grpcio] ?= "Depends on blacklisted python3-protobuf which is not compatible with old protobuf from meta-webos/recipes-devtools/protobuf/protobuf_3.6.1.bb"
+PNBLACKLIST[python3-grpcio-tools] ?= "Depends on blacklisted python3-protobuf which is not compatible with old protobuf from meta-webos/recipes-devtools/protobuf/protobuf_3.6.1.bb"
+PNBLACKLIST_GATOR = ""
+PNBLACKLIST_GATOR_x86 = "Not compatible with qemux86 kernel: #error gator requires the kernel to have CONFIG_PROFILING defined; after enabling CONFIG_PROFILING still fails with: work/qemux86-webos-linux/gator/6.7+gitAUTOINC+3ff46fedd4-r2/git/driver/gator_main.c:1399:41: error: initialization of 'struct tracepoint * const*' from incompatible pointer type 'const tracepoint_ptr_t *' {aka 'const int *'} [-Werror=incompatible-pointer-types]; fixed in gator 6.9"
+PNBLACKLIST[gator] ?= "${PNBLACKLIST_GATOR}"


### PR DESCRIPTION
webos-compat.inc: blacklist gator and python3-protobuf, python3-grpcio(-tools)

* both are failing with OSE v2.7.0
* meta-python/recipes-devtools/python/python3-protobuf_3.11.3.bb:
  google/protobuf/pyext/message.cc:70:10: fatal error: google/protobuf/stubs/map_util.h: No such file or directory
     70 | #include <google/protobuf/stubs/map_util.h>
        |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  compilation terminated.
  error: command 'arm-webos-linux-gnueabi-gcc' failed with exit status 1

* gator:
  qemux86-webos-linux/gator/6.7+gitAUTOINC+3ff46fedd4-r2/git/driver/gator_main.c:54:2: error: #error gator requires the kernel to have CONFIG_PROFILING defined
     54 | #error gator requires the kernel to have CONFIG_PROFILING defined
        |  ^~~~~
  qemux86-webos-linux/gator/6.7+gitAUTOINC+3ff46fedd4-r2/git/driver/gator_main.c: In function 'gator_new_tracepoint_module':
  qemux86-webos-linux/gator/6.7+gitAUTOINC+3ff46fedd4-r2/git/driver/gator_main.c:1399:41: error: initialization of 'struct tracepoint * const*' from incompatible pointer type 'const tracepoint_ptr_t *' {aka 'const int *'} [-Werror=incompatible-pointer-types]
   1399 |     struct tracepoint * const * begin = tp_mod->mod->tracepoints_ptrs;
        |                                         ^~~~~~
  qemux86-webos-linux/gator/6.7+gitAUTOINC+3ff46fedd4-r2/git/driver/gator_main.c:1400:39: error: initialization of 'struct tracepoint * const*' from incompatible pointer type 'const tracepoint_ptr_t *' {aka 'const int *'} [-Werror=incompatible-pointer-types]
   1400 |     struct tracepoint * const * end = tp_mod->mod->tracepoints_ptrs + tp_mod->mod->num_tracepoints;
        |                                       ^~~~~~
  cc1: some warnings being treated as errors

Signed-off-by: Martin Jansa <martin.jansa@lge.com>