### PR TITLE
webos-compat.inc: re-blacklist omxplayer

### DIFF
--- a/conf/ros-distro/include/webos-compat.inc
+++ b/conf/ros-distro/include/webos-compat.inc
@@ -56,3 +56,7 @@ PNBLACKLIST[gstd] ?= "Depends on blacklisted gstreamer1.0-rtsp-server"
 # meta-ros-common/conf/ros-distro/include/ros-world-recipe-blacklist.inc:PNBLACKLIST[packagegroup-meta-multimedia] ?= "${@bb.utils.contains('ROS_WORLD_SKIP_GROUPS', 'world-license', 'rdepends on gstd, gst-shark which depend on gstreamer1.0-plugins-bad which depends on faad2 which has a restricted license not whitelisted in LICENSE_FLAGS_WHITELIST', '', d)}"
 # meta-webos/conf/distro/include/webos-recipe-blacklist.inc:PNBLACKLIST[packagegroup-meta-multimedia] ?= "Depends on blacklisted gstd, gerbera, rygel"
 PNBLACKLIST[packagegroup-meta-multimedia] ?= "Depends on blacklisted gstd, gerbera, rygel"
+
+# meta-raspberrypi/recipes-multimedia/omxplayer/omxplayer_git.bb:do_compile
+# meta-webos/conf/distro/include/webos-recipe-blacklist.inc:PNBLACKLIST[omxplayer] ?= "ERROR: omxplayer-git-r4 do_compile: Function failed: do_compile: DllAvFormat.h:117:51: error: ::avio_feof has not been declared"
+PNBLACKLIST[omxplayer] ?= "ERROR: omxplayer-git-r4 do_compile: Function failed: do_compile: DllAvFormat.h:117:51: error: ::avio_feof has not been declared"


### PR DESCRIPTION
* meta-webosose blacklists it already:
```
  meta-webos-raspberrypi/conf/machine/include/webos-rpi.inc:PNBLACKLIST[omxplayer] ?= "not compatible with webOS Open components"
  meta-webos-raspberrypi/conf/machine/include/webos-rpi.inc:PNBLACKLIST[packagegroup-rpi-test] ?= "rdepends on omxplayer"
  meta-webos/conf/distro/include/webos-recipe-blacklist.inc:PNBLACKLIST[omxplayer] ?= "ERROR: omxplayer-git-r4 do_compile: Function failed: do_compile: DllAvFormat.h:117:51: error: ::avio_feof has not been declared"
```

* but meta-ros-common has different conditional blacklist:
```
  meta-ros-common/conf/ros-distro/include/ros-world-recipe-blacklist.inc:PNBLACKLIST[omxplayer] ?= "${@bb.utils.contains('ROS_WORLD_SKIP_GROUPS', 'world-license', 'depends on libav, libomxil which has a restricted license not whitelisted in LICENSE_FLAGS_WHITELIST', '', d)}"
```

  now when PNBLACKLISTs were removed here in webos-compat.inc (which is
  included from meta-ros-webos/conf/layer.conf), the ros-world-recipe-blacklist.inc
  is parsed first, so the conditional is respected, but then in webOS OSE builds
  it conflicts with libavutil and libswresample:

```
ERROR: omxplayer-git-r5 do_package: omxplayer: Multiple shlib providers for libavformat.so.58: libavformat, omxplayer (used by files: /jenkins/home/workspace/jansa/webos-melodic-hardknott/webos-melodic-hardknott/tmp-glibc/work/raspberrypi4-webos-linux-gnueabi/omxplayer/git-r5/packages-split/omxplayer/usr/bin/omxplayer.bin)
ERROR: omxplayer-git-r5 do_package: omxplayer: Multiple shlib providers for libavutil.so.56: libavutil, omxplayer (used by files: /jenkins/home/workspace/jansa/webos-melodic-hardknott/webos-melodic-hardknott/tmp-glibc/work/raspberrypi4-webos-linux-gnueabi/omxplayer/git-r5/packages-split/omxplayer/usr/lib/omxplayer/libavfilter.so.7.16.100)
ERROR: omxplayer-git-r5 do_package: omxplayer: Multiple shlib providers for libavutil.so.56: libavutil, omxplayer (used by files: /jenkins/home/workspace/jansa/webos-melodic-hardknott/webos-melodic-hardknott/tmp-glibc/work/raspberrypi4-webos-linux-gnueabi/omxplayer/git-r5/packages-split/omxplayer/usr/bin/omxplayer.bin)
ERROR: omxplayer-git-r5 do_package: omxplayer: Multiple shlib providers for libswscale.so.5: libswscale, omxplayer (used by files: /jenkins/home/workspace/jansa/webos-melodic-hardknott/webos-melodic-hardknott/tmp-glibc/work/raspberrypi4-webos-linux-gnueabi/omxplayer/git-r5/packages-split/omxplayer/usr/bin/omxplayer.bin)
ERROR: omxplayer-git-r5 do_package: omxplayer: Multiple shlib providers for libavutil.so.56: libavutil, omxplayer (used by files: /jenkins/home/workspace/jansa/webos-melodic-hardknott/webos-melodic-hardknott/tmp-glibc/work/raspberrypi4-webos-linux-gnueabi/omxplayer/git-r5/packages-split/omxplayer/usr/lib/omxplayer/libavcodec.so.58.18.100)
ERROR: omxplayer-git-r5 do_package: omxplayer: Multiple shlib providers for libavcodec.so.58: libavcodec, omxplayer (used by files: /jenkins/home/workspace/jansa/webos-melodic-hardknott/webos-melodic-hardknott/tmp-glibc/work/raspberrypi4-webos-linux-gnueabi/omxplayer/git-r5/packages-split/omxplayer/usr/lib/omxplayer/libavformat.so.58.12.100)
ERROR: omxplayer-git-r5 do_package: omxplayer: Multiple shlib providers for libswresample.so.3: libswresample, omxplayer (used by files: /jenkins/home/workspace/jansa/webos-melodic-hardknott/webos-melodic-hardknott/tmp-glibc/work/raspberrypi4-webos-linux-gnueabi/omxplayer/git-r5/packages-split/omxplayer/usr/lib/omxplayer/libavcodec.so.58.18.100)
ERROR: omxplayer-git-r5 do_package: omxplayer: Multiple shlib providers for libavutil.so.56: libavutil, omxplayer (used by files: /jenkins/home/workspace/jansa/webos-melodic-hardknott/webos-melodic-hardknott/tmp-glibc/work/raspberrypi4-webos-linux-gnueabi/omxplayer/git-r5/packages-split/omxplayer/usr/lib/omxplayer/libswscale.so.5.1.100)
ERROR: omxplayer-git-r5 do_package: omxplayer: Multiple shlib providers for libavutil.so.56: libavutil, omxplayer (used by files: /jenkins/home/workspace/jansa/webos-melodic-hardknott/webos-melodic-hardknott/tmp-glibc/work/raspberrypi4-webos-linux-gnueabi/omxplayer/git-r5/packages-split/omxplayer/usr/lib/omxplayer/libavformat.so.58.12.100)
ERROR: omxplayer-git-r5 do_package: omxplayer: Multiple shlib providers for libavcodec.so.58: libavcodec, omxplayer (used by files: /jenkins/home/workspace/jansa/webos-melodic-hardknott/webos-melodic-hardknott/tmp-glibc/work/raspberrypi4-webos-linux-gnueabi/omxplayer/git-r5/packages-split/omxplayer/usr/bin/omxplayer.bin)
ERROR: omxplayer-git-r5 do_package: omxplayer: Multiple shlib providers for libavutil.so.56: libavutil, omxplayer (used by files: /jenkins/home/workspace/jansa/webos-melodic-hardknott/webos-melodic-hardknott/tmp-glibc/work/raspberrypi4-webos-linux-gnueabi/omxplayer/git-r5/packages-split/omxplayer/usr/lib/omxplayer/libavdevice.so.58.3.100)
ERROR: omxplayer-git-r5 do_package: omxplayer: Multiple shlib providers for libswresample.so.3: libswresample, omxplayer (used by files: /jenkins/home/workspace/jansa/webos-melodic-hardknott/webos-melodic-hardknott/tmp-glibc/work/raspberrypi4-webos-linux-gnueabi/omxplayer/git-r5/packages-split/omxplayer/usr/bin/omxplayer.bin)
ERROR: omxplayer-git-r5 do_package: omxplayer: Multiple shlib providers for libavformat.so.58: libavformat, omxplayer (used by files: /jenkins/home/workspace/jansa/webos-melodic-hardknott/webos-melodic-hardknott/tmp-glibc/work/raspberrypi4-webos-linux-gnueabi/omxplayer/git-r5/packages-split/omxplayer/usr/lib/omxplayer/libavdevice.so.58.3.100)
ERROR: omxplayer-git-r5 do_package: omxplayer: Multiple shlib providers for libavutil.so.56: libavutil, omxplayer (used by files: /jenkins/home/workspace/jansa/webos-melodic-hardknott/webos-melodic-hardknott/tmp-glibc/work/raspberrypi4-webos-linux-gnueabi/omxplayer/git-r5/packages-split/omxplayer/usr/lib/omxplayer/libswresample.so.3.1.100)
```

Signed-off-by: Martin Jansa <martin.jansa@lge.com>