### PR TITLE
libxml2=webos1 (fix file-rdeps QA issue fix about /bin/bash)

### DIFF
--- a/recipes-core/libxml/libxml2_%.bbappend
+++ b/recipes-core/libxml/libxml2_%.bbappend
@@ -1,0 +1,8 @@
+# Copyright (c) 2021 LG Electronics, Inc.
+
+EXTENDPRAUTO_append = "webos1"
+
+# ERROR: libxml2-2.9.10-r0 do_package_qa: QA Issue: libxml2-ptest rdepends on bash, but it isn't a build dependency, missing bash in DEPENDS or PACKAGECONFIG? [build-deps]
+VIRTUAL-RUNTIME_bash ?= "bash"
+RDEPENDS_${PN}-ptest_append_class-target = " ${VIRTUAL-RUNTIME_bash}"
+RDEPENDS_${PN}-ptest_remove_class-target = "${@oe.utils.conditional('WEBOS_PREFERRED_PROVIDER_FOR_BASH', 'busybox', 'bash', '', d)}"


### PR DESCRIPTION
:Release Notes:
Temporarily in meta-ros-webos until new webOS OSE release is available with this
included.

:Detailed Notes:
libxml2: added in:
https://git.openembedded.org/openembedded-core/commit/?id=d2e81298c446aec8d7fcf61fd5023ac30350f205
backported to dunfell in:
https://git.openembedded.org/openembedded-core/commit/?h=dunfell&id=bc1d05429da1101d910b4ccf3de5407ddfbedc92
fixes:
ERROR: libxml2-2.9.10-r0 do_package_qa: QA Issue: libxml2-ptest rdepends on bash, but it isn't a build dependency, missing bash in DEPENDS or PACKAGECONFIG? [build-deps]

:Testing Performed:
Only build tested.

:QA Notes:
No change to image.

:Issues Addressed:
[PLAT-144786] CCC: Upgrade to latest revisions from Yocto 3.1 Dunfell

Change-Id: I59ddf37214a0c979ab4e45b97ab32f8912879e80