### PR TITLE
[dunfell] webos_ls2_api_info.bbclass: Fix python exception when buildhistory is…

### DIFF
--- a/classes/webos_ls2_api_info.bbclass
+++ b/classes/webos_ls2_api_info.bbclass
@@ -1,0 +1,17 @@
+# Copyright (c) 2021 LG Electronics, Inc.
+
+LS2_DIR = "${IMAGE_ROOTFS}${datadir}/luna-service2"
+
+webos_ls2_api_info_data () {
+    if [ -d "${LS2_DIR}" -a -n "${BUILDHISTORY_DIR_IMAGE}" ] ; then
+        cd ${LS2_DIR}
+        if [ -d ${BUILDHISTORY_DIR_IMAGE}/ls2_api ] ; then
+            rm -rf ${BUILDHISTORY_DIR_IMAGE}/ls2_api
+        fi
+        mkdir -p ${BUILDHISTORY_DIR_IMAGE}/ls2_api
+        cp -r ./* ${BUILDHISTORY_DIR_IMAGE}/ls2_api/
+        cd -
+    fi
+}
+
+ROOTFS_POSTPROCESS_COMMAND += "webos_ls2_api_info_data ;"


### PR DESCRIPTION
…n't enabled

:Release Notes:
Temporary add this bbclass from meta-webosose with additional fix:

Check that BUILDHISTORY_DIR_IMAGE isn't empty before trying to create ls2_api
directory inside it and failing with:
mkdir: cannot create directory ‘/ls2_api’: Permission denied

:Detailed Notes:
Fixes:
```
ERROR: webos-image-ros-core-1.0-r3 do_rootfs: Error executing a python function in exec_python_func() autogenerated:

The stack trace of python calls that resulted in this exception/failure was:
File: 'exec_python_func() autogenerated', lineno: 2, function: <module>
     0001:
 *** 0002:do_rootfs(d)
     0003:
File: 'openembedded-core/meta/classes/image.bbclass', lineno: 247, function: do_rootfs
     0243:    progress_reporter.next_stage()
     0244:
     0245:    # generate rootfs
     0246:    d.setVarFlag('REPRODUCIBLE_TIMESTAMP_ROOTFS', 'export', '1')
 *** 0247:    create_rootfs(d, progress_reporter=progress_reporter, logcatcher=logcatcher)
     0248:
     0249:    progress_reporter.finish()
     0250:}
     0251:do_rootfs[dirs] = "${TOPDIR}"
File: 'openembedded-core/meta/lib/oe/rootfs.py', lineno: 373, function: create_rootfs
     0369:
     0370:    img_type = d.getVar('IMAGE_PKGTYPE')
     0371:
     0372:    cls = get_class_for_type(img_type)
 *** 0373:    cls(d, manifest_dir, progress_reporter, logcatcher).create()
     0374:    os.environ.clear()
     0375:    os.environ.update(env_bkp)
     0376:
     0377:
File: 'openembedded-core/meta/lib/oe/rootfs.py', lineno: 214, function: create
     0210:        execute_pre_post_process(self.d, rootfs_post_install_cmds)
     0211:
     0212:        self.pm.run_intercepts()
     0213:
 *** 0214:        execute_pre_post_process(self.d, post_process_cmds)
     0215:
     0216:        if self.progress_reporter:
     0217:            self.progress_reporter.next_stage()
     0218:
File: 'openembedded-core/meta/lib/oe/utils.py', lineno: 263, function: execute_pre_post_process
     0259:    for cmd in cmds.strip().split(';'):
     0260:        cmd = cmd.strip()
     0261:        if cmd != '':
     0262:            bb.note("Executing %s ..." % cmd)
 *** 0263:            bb.build.exec_func(cmd, d)
     0264:
     0265:# For each item in items, call the function 'target' with item as the first
     0266:# argument, extraargs as the other arguments and handle any exceptions in the
     0267:# parent thread
File: 'bitbake/lib/bb/build.py', lineno: 256, function: exec_func
     0252:    with bb.utils.fileslocked(lockfiles):
     0253:        if ispython:
     0254:            exec_func_python(func, d, runfile, cwd=adir)
     0255:        else:
 *** 0256:            exec_func_shell(func, d, runfile, cwd=adir)
     0257:
     0258:    try:
     0259:        curcwd = os.getcwd()
     0260:    except:
File: 'bitbake/lib/bb/build.py', lineno: 503, function: exec_func_shell
     0499:    with open(fifopath, 'r+b', buffering=0) as fifo:
     0500:        try:
     0501:            bb.debug(2, "Executing shell function %s" % func)
     0502:            with open(os.devnull, 'r+') as stdin, logfile:
 *** 0503:                bb.process.run(cmd, shell=False, stdin=stdin, log=logfile, extrafiles=[(fifo,readfifo)])
     0504:        except bb.process.ExecutionError as exe:
     0505:            # Find the backtrace that the shell trap generated
     0506:            backtrace_marker_regex = re.compile(r"WARNING: Backtrace \(BB generated script\)")
     0507:            stdout_lines = (exe.stdout or "").split("\n")
File: 'bitbake/lib/bb/process.py', lineno: 184, function: run
     0180:        if not stderr is None:
     0181:            stderr = stderr.decode("utf-8")
     0182:
     0183:    if pipe.returncode != 0:
 *** 0184:        raise ExecutionError(cmd, pipe.returncode, stdout, stderr)
     0185:    return stdout, stderr
Exception: bb.process.ExecutionError: Execution of 'tmp-glibc/work/raspberrypi4-webos-linux-gnueabi/webos-image-ros-core/1.0-r3/temp/run.webos_ls2_api_info_data.49315' failed with exit code 1:
mkdir: cannot create directory ‘/ls2_api’: Permission denied
WARNING: tmp-glibc/work/raspberrypi4-webos-linux-gnueabi/webos-image-ros-core/1.0-r3/temp/run.webos_ls2_api_info_data.49315:166 exit 1 from 'mkdir -p ${BUILDHISTORY_DIR_IMAGE}/ls2_api'
WARNING: Backtrace (BB generated script):
	#1: webos_ls2_api_info_data, tmp-glibc/work/raspberrypi4-webos-linux-gnueabi/webos-image-ros-core/1.0-r3/temp/run.webos_ls2_api_info_data.49315, line 166
	#2: main, tmp-glibc/work/raspberrypi4-webos-linux-gnueabi/webos-image-ros-core/1.0-r3/temp/run.webos_ls2_api_info_data.49315, line 172

Backtrace (metadata-relative locations):
	#1: webos_ls2_api_info_data, meta-webosose/meta-webos/classes/webos_ls2_api_info.bbclass, line 11

ERROR: Logfile of failure stored in: tmp-glibc/work/raspberrypi4-webos-linux-gnueabi/webos-image-ros-core/1.0-r3/temp/log.do_rootfs.49315
```

:Testing Performed:
Local OK

:QA Notes:
N/A

:Issues Addressed:
[PLAT-141744] Create api data in buildhistory

Change-Id: If8d60721e0f36b9353bb0f1899e029537b1a51b1